### PR TITLE
make it a proper module... need to reduce code size.

### DIFF
--- a/contracts/MultisendEncoder.sol
+++ b/contracts/MultisendEncoder.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.6;
+
+import "./Transaction.sol";
+
+abstract contract MultisendEncoder {
+    address internal multisend;
+
+    function encodeMultisend(Transaction[] memory txs)
+        public
+        view
+        returns (
+            address to,
+            uint256 value,
+            bytes memory data,
+            Enum.Operation operation
+        )
+    {
+        require(
+            txs.length > 0,
+            "No transactions provided for multisend encode"
+        );
+
+        if (txs.length > 1) {
+            to = multisend;
+            value = 0;
+            data = hex"";
+            for (uint256 i; i < txs.length; i++) {
+                data = abi.encodePacked(
+                    data,
+                    abi.encodePacked(
+                        uint8(txs[i].operation),
+                        txs[i].to,
+                        txs[i].value,
+                        uint256(txs[i].data.length),
+                        txs[i].operation
+                    )
+                );
+            }
+            operation = Enum.Operation.Call;
+        } else {
+            to = txs[0].to;
+            value = txs[0].value;
+            data = txs[0].data;
+            operation = txs[0].operation;
+        }
+    }
+}

--- a/contracts/OZGovernorModule.sol
+++ b/contracts/OZGovernorModule.sol
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.9;
 
-import "@gnosis.pm/zodiac/contracts/factory/FactoryFriendly.sol";
+import "@gnosis.pm/zodiac/contracts/core/Module.sol";
+import "./MultisendEncoder.sol";
 import "@openzeppelin/contracts-upgradeable/governance/GovernorUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorSettingsUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorCountingSimpleUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorVotesUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorVotesQuorumFractionUpgradeable.sol";
 
-contract OZGovernorModule is FactoryFriendly, GovernorUpgradeable, GovernorSettingsUpgradeable, GovernorCountingSimpleUpgradeable, GovernorVotesUpgradeable, GovernorVotesQuorumFractionUpgradeable {
-        constructor(address _owner, address _token, string memory _name, uint256 _votingDelay, uint256 _votingPeriod, uint256 _proposalThreshold, uint256 _quorum) {
-        bytes memory initializeParams = abi.encode(_owner, _token, _name, _votingDelay, _votingPeriod, _proposalThreshold, _quorum);
+contract OZGovernorModule is Module, MultisendEncoder, GovernorUpgradeable, GovernorSettingsUpgradeable, GovernorCountingSimpleUpgradeable, GovernorVotesUpgradeable, GovernorVotesQuorumFractionUpgradeable {
+    constructor(address _owner, address _avatar, address _target, address _token, string memory _name, uint256 _votingDelay, uint256 _votingPeriod, uint256 _proposalThreshold, uint256 _quorum) {
+        bytes memory initializeParams = abi.encode(_owner, _avatar, _target, _token, _name, _votingDelay, _votingPeriod, _proposalThreshold, _quorum);
         setUp(initializeParams);
     }
 
@@ -18,13 +19,37 @@ contract OZGovernorModule is FactoryFriendly, GovernorUpgradeable, GovernorSetti
     /// @param initializeParams Parameters of initialization encoded
     function setUp(bytes memory initializeParams) public override initializer {
         __Ownable_init();
-        (address _owner, address _token, string memory _name, uint256 _votingDelay, uint256 _votingPeriod, uint256 _proposalThreshold, uint256 _quorum) = abi.decode(initializeParams, (address, address, string, uint256, uint256, uint256, uint256));
+        (address _owner, address _avatar, address _target, address _token, string memory _name, uint256 _votingDelay, uint256 _votingPeriod, uint256 _proposalThreshold, uint256 _quorum) = abi.decode(initializeParams, (address, address, address, address, string, uint256, uint256, uint256, uint256));
+
+        setAvatar(_avatar);
+        setTarget(_target);
         __Governor_init(_name);
         __GovernorSettings_init(_votingDelay, _votingPeriod, _proposalThreshold);
         __GovernorCountingSimple_init();
         __GovernorVotes_init(IVotesUpgradeable(_token));
         __GovernorVotesQuorumFraction_init(_quorum);
         transferOwnership(_owner);
+    }
+
+    /// @dev Execute via a Zodiac avatar, like a Gnosis Safe.
+    function _execute(
+        uint256, /* proposalId */
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 /*descriptionHash*/
+    ) internal override {
+        string memory errorMessage = "Governor: call reverted without message";
+        require(targets.length == values.length && values.length == calldatas.length, "arrays are not equal length");
+        Transaction[] memory transactions;
+        for(uint8 i = 0; i < targets.length; i++){
+            transactions[i].to = targets[i];
+            transactions[i].value = values[i];
+            transactions[i].data = calldatas[i];
+            transactions[i].operation = Enum.Operation.Call;
+        }
+        (address to, uint256 value, bytes memory data, Enum.Operation operation) = encodeMultisend(transactions);
+        exec(to, value, data, operation);
     }
 
     // The following functions are overrides required by Solidity.

--- a/contracts/Transaction.sol
+++ b/contracts/Transaction.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.6;
+
+import "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
+
+struct Transaction {
+    address to;
+    uint256 value;
+    bytes data;
+    Enum.Operation operation;
+}

--- a/test/OZGovernorModule.test.ts
+++ b/test/OZGovernorModule.test.ts
@@ -13,6 +13,8 @@ const setup = async () => {
   const OZGovernorModuleFactory = await ethers.getContractFactory("OZGovernorModule")
   const ozGovernorModule = await OZGovernorModuleFactory.deploy(
     testSigner.address,
+    avatar.address,
+    avatar.address,
     AddressOne,
     "Test Governor",
     1,
@@ -20,19 +22,24 @@ const setup = async () => {
     0,
     1,
   )
+
   return { avatar, ozGovernorModule, testSigner }
 }
 
 describe("OZGovernorModule", function () {
   describe("Constructor", function () {
     it("Successfully deploys contract and sets variables", async function () {
-      const { ozGovernorModule, testSigner } = await setup()
+      const { avatar, ozGovernorModule, testSigner } = await setup()
       expect(await ozGovernorModule.owner()).to.equal(testSigner.address)
+      expect(await ozGovernorModule.avatar()).to.equal(avatar.address)
+      expect(await ozGovernorModule.target()).to.equal(avatar.address)
       expect(await ozGovernorModule.token()).to.equal(AddressOne)
       expect(await ozGovernorModule.name()).to.equal("Test Governor")
       expect(await ozGovernorModule.votingDelay()).to.equal(1)
       expect(await ozGovernorModule.votingPeriod()).to.equal(60)
       expect(await ozGovernorModule.proposalThreshold()).to.equal(0)
+      const blockNumber = await ethers.provider.getBlockNumber()
+      expect(await ozGovernorModule.quorum(blockNumber)).to.equal(1)
     })
   })
 })


### PR DESCRIPTION
This PR makes the OZ module a proper module, rather than just inheriting factory friendly.

The nice thing about this is that it will work out of the box with existing governor UIs, without requiring them to understand how to encode transactions to `avatar.execTransactionFromModule()`.